### PR TITLE
Add electron app for certificate and stanza export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/certificate-electron/README.md
+++ b/certificate-electron/README.md
@@ -1,0 +1,18 @@
+# Certificate Electron App
+
+This simple Electron app converts a raw data workbook into two sheets:
+- **Certificate** for printing certificates
+- **Stanza** for students with stanzas
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the app:
+   ```bash
+   npm start
+   ```
+3. Click **Select Excel** to choose the source workbook.
+4. Click **Generate Export** to save *Sample Data export.xlsx* with the two sheets.

--- a/certificate-electron/index.html
+++ b/certificate-electron/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Certificate Generator</title>
+</head>
+<body>
+  <button id="upload">Select Excel</button>
+  <button id="generate" disabled>Generate Export</button>
+  <div id="filePath"></div>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/certificate-electron/main.js
+++ b/certificate-electron/main.js
@@ -1,0 +1,104 @@
+const { app, BrowserWindow, ipcMain, dialog } = require('electron');
+const path = require('path');
+const XLSX = require('xlsx');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+function processWorkbook(sourcePath) {
+  const wb = XLSX.readFile(sourcePath);
+  const certificateRows = [];
+  const stanzaRows = [];
+  const certSeq = {};
+  const stanzaSeq = {};
+
+  Object.values(wb.Sheets).forEach(sheet => {
+    const json = XLSX.utils.sheet_to_json(sheet);
+    json.forEach(row => {
+      const fullName = [row['First Name'], row['Middle Name'], row['Last Name']]
+        .filter(Boolean)
+        .join(' ');
+      const genderWord = row['Gender'] === 'Male' ? 'His' : 'Her';
+      const cls = row['Class'];
+      const teacher = row['Class Teacher Name'];
+      ['Sinhala', 'Buddhism'].forEach(subject => {
+        const grades = ['Higher Distinction', 'Distinction', 'Credit', 'Pass', 'Participate'];
+        const achieved = grades.find(g =>
+          String(row[`${subject}-Grade ${g}`]).match(/^(x|yes|1)$/i)
+        );
+        if (!achieved) return;
+        certSeq[cls] ??= { Sinhala: 0, Buddhism: 0 };
+        certSeq[cls][subject]++;
+        const certNo = `G${cls}${subject === 'Buddhism' ? 'B' : 'S'}${String(
+          certSeq[cls][subject]
+        ).padStart(3, '0')}`;
+        certificateRows.push({
+          NAME: fullName,
+          Gender: genderWord,
+          Achievement: achieved,
+          Subject: subject,
+          Class: cls,
+          Teacher: teacher,
+          CertificateNo: certNo,
+        });
+        if (String(row['Stanzas']).match(/^(x|yes|1)$/i)) {
+          stanzaSeq[cls] ??= 0;
+          stanzaSeq[cls]++;
+          const stanzaNo = `G${cls}G${String(stanzaSeq[cls]).padStart(3, '0')}`;
+          stanzaRows.push({
+            StudentName: fullName,
+            Class: cls,
+            CertificateNumber: stanzaNo,
+            Teacher: teacher,
+          });
+        }
+      });
+    });
+  });
+
+  return { certificateRows, stanzaRows };
+}
+
+ipcMain.handle('dialog:openFile', async () => {
+  const { canceled, filePaths } = await dialog.showOpenDialog({
+    properties: ['openFile'],
+    filters: [{ name: 'Excel', extensions: ['xlsx'] }],
+  });
+  if (canceled) return null;
+  return filePaths[0];
+});
+
+ipcMain.handle('generate-export', async (_, sourcePath) => {
+  if (!sourcePath) return null;
+  const { certificateRows, stanzaRows } = processWorkbook(sourcePath);
+  const outWB = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(outWB, XLSX.utils.json_to_sheet(certificateRows), 'Certificate');
+  XLSX.utils.book_append_sheet(outWB, XLSX.utils.json_to_sheet(stanzaRows), 'Stanza');
+  const { filePath } = await dialog.showSaveDialog({
+    defaultPath: path.join(path.dirname(sourcePath), 'Sample Data export.xlsx'),
+  });
+  if (filePath) {
+    XLSX.writeFile(outWB, filePath);
+    return filePath;
+  }
+  return null;
+});

--- a/certificate-electron/package.json
+++ b/certificate-electron/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "certificate-electron",
+  "version": "1.0.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "electron": "^25.5.0",
+    "xlsx": "^0.18.5"
+  }
+}

--- a/certificate-electron/preload.js
+++ b/certificate-electron/preload.js
@@ -1,0 +1,6 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  openFile: () => ipcRenderer.invoke('dialog:openFile'),
+  generateExport: (path) => ipcRenderer.invoke('generate-export', path),
+});

--- a/certificate-electron/renderer.js
+++ b/certificate-electron/renderer.js
@@ -1,0 +1,15 @@
+const uploadBtn = document.getElementById('upload');
+const generateBtn = document.getElementById('generate');
+const filePathSpan = document.getElementById('filePath');
+let selectedPath;
+
+uploadBtn.addEventListener('click', async () => {
+  selectedPath = await window.electronAPI.openFile();
+  filePathSpan.textContent = selectedPath || '';
+  generateBtn.disabled = !selectedPath;
+});
+
+generateBtn.addEventListener('click', async () => {
+  const outPath = await window.electronAPI.generateExport(selectedPath);
+  if (outPath) alert(`Exported to ${outPath}`);
+});


### PR DESCRIPTION
## Summary
- add Electron desktop example that converts a class workbook into Certificate and Stanza sheets
- expose renderer buttons to pick a workbook and generate the export
- ignore node_modules repository-wide

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/electron)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6fc84b384832998642d33c07b8bb3